### PR TITLE
Fix in SugarCasesConnection.php getCases() call of fromSugarCases()

### DIFF
--- a/site/models/SugarCasesConnection.php
+++ b/site/models/SugarCasesConnection.php
@@ -274,7 +274,7 @@ class SugarCasesConnection {
     private function fromSugarCases($sugarcases){
         $cases = array();
         foreach($sugarcases['entry_list'] as $sugarcase){
-            $cases[] = new SugarCase($sugarcase);
+            $cases[] = new SugarCase($sugarcase,array());
         }
         return $cases;
     }


### PR DESCRIPTION
SugarCase() expects two parameters but only one is given. It appears that supplying an empty array helps and makes AOP usable again. Still this needs to be revised to correctly add the required relationships.